### PR TITLE
add mp4 format to show; fix a bug in visualize

### DIFF
--- a/src/tensorneat/problem/rl/brax.py
+++ b/src/tensorneat/problem/rl/brax.py
@@ -42,7 +42,7 @@ class BraxEnv(RLEnv):
             **kwargs,
         ):
 
-        assert output_type in ["rgb_array", "gif"]
+        assert output_type in ["rgb_array", "gif", "mp4"]
 
         import jax
         import imageio
@@ -93,8 +93,14 @@ class BraxEnv(RLEnv):
             return imgs
 
         if save_path is None:
-            save_path = f"{self.env_name}.gif"
+            save_path = f"{self.env_name}.{output_type}"
 
         imageio.mimsave(save_path, imgs, *args, **kwargs)
 
-        print("Gif saved to: ", save_path)
+        if output_type == "gif":
+            imageio.mimsave(save_path, imgs, *args, **kwargs)
+        elif output_type == "mp4":
+            fps = kwargs.get("fps", 30)
+            imageio.mimsave(save_path, imgs, fps=fps, codec="libx264", format="mp4")
+
+        print(f"{output_type} saved to: ", save_path)


### PR DESCRIPTION
I add the following part in DefaultGnome.visulize
```
# reorder nodes in each layer to make them more compact
subset_key = {}
for layer, nodes in enumerate(topo_layers):
    if layer == 0 or len(nodes) == 1:
        subset_key[layer] = nodes
        continue
    nodes_y = []
    for node in nodes:
        node_y = 0
        for y, last_node in enumerate(topo_layers[layer-1]):
            if (last_node, node) in conns_list:
                node_y += y
        nodes_y.append(node_y)
    nodes = [node for _, node in sorted(zip(nodes_y, nodes))]
    subset_key[layer] = nodes
```
This also solves the problem of `reverse_node_order` having no effect.
```
if reverse_node_order:
            for layer, nodes in subset_key.items():
                subset_key[layer] = nodes[::-1]
```
