### PR TITLE
Show details for previous generation, not next one

### DIFF
--- a/src/tensorneat/pipeline.py
+++ b/src/tensorneat/pipeline.py
@@ -232,7 +232,7 @@ class Pipeline(StatefulBaseClass):
 
         if self.show_problem_details:
             pop_transformed = self.compiled_pop_transform_func(
-                state, self.algorithm.ask(state)
+                state, pop #using previous pop instead of requesting the new one from state here
             )
             self.problem.show_details(
                 state, state.randkey, self.algorithm.forward, pop_transformed


### PR DESCRIPTION
Hello! 
It seems like `analysis()` in `pipeline.py` uses the next generation when calling `show_details()`. To reflect which generation is used for printing the fitness in the part a couple of lines above, I propose using the `pop` argument from the `analysis()` function, which should be the previous population, instead of requesting the new generation from the state.
Thank you for all your hard work!