### PR TITLE
Reduce feed-forward adjacency memory with bounded inbound storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,40 @@ This works even when each individual in the population has a **different topolog
 
 See `./examples/func_fit/xor_grad.py` for a complete example that initializes a population, mutates them into diverse topologies, and optimizes all of them with pure gradient descent. 
 
+## Bounding Feed-Forward Adjacency Memory
+
+TensorNEAT's fixed-shape graph representation is what makes whole populations
+compatible with JAX transformations and accelerator execution. The trade-off is
+that feed-forward inference currently expands every genome to a
+`max_nodes x max_nodes` adjacency, so memory grows with the configured node
+capacity even when evolved graphs are sparse.
+
+For workloads that reserve many nodes but can bound fan-in, `DefaultGenome` can
+instead store at most `K` inbound connection indices per node:
+
+```python
+genome = DefaultGenome(
+    num_inputs=3,
+    num_outputs=1,
+    max_nodes=512,
+    max_conns=2048,
+    max_in_degree=64,
+)
+```
+
+This changes the transformed adjacency shape from
+`(max_nodes, max_nodes)` to `(max_nodes, K)`. The cap is checked against the
+initial topology and enforced when adding connections through
+`DefaultMutation`. A transformed genome that violates the cap produces NaN
+outputs rather than silently dropping connections.
+
+The default, `max_in_degree=None`, keeps the existing dense implementation
+unchanged. This option currently applies only to `DefaultGenome`;
+`RecurrentGenome` continues to use its dense recurrent representation.
+It is complementary to `pop_batch_size`: batching bounds how many genomes are
+transformed at once, while `max_in_degree` bounds each transformed genome's
+feed-forward adjacency.
+
 ## Basic API Usage
 Start your journey with TensorNEAT in a few simple steps:
 
@@ -463,4 +497,3 @@ If you use TensorNEAT in your research and want to cite it in your work, please 
   keywords = {Neuroevolution, GPU Acceleration, Algorithm Library}
 }
 ```
-

--- a/src/tensorneat/common/graph.py
+++ b/src/tensorneat/common/graph.py
@@ -115,7 +115,116 @@ def find_useful_nodes(
             useful_nodes = useful_nodes | aux
     # print(f"All nodes cnt={len(nodes)}, useful nodes cnt={len(useful_nodes)}")
     return useful_nodes            
-        
+
+
+def topological_sort_flat(
+    nodes: Array, src_rows: Array, dst_rows: Array, valid: Array
+) -> Array:
+    """
+    Topologically sort nodes directly from flat connection endpoints.
+
+    This is Kahn's algorithm over ``(C,)`` source and destination row arrays.
+    It avoids constructing the dense ``(N, N)`` connectivity matrix used by
+    :func:`topological_sort`.
+    """
+    max_nodes = nodes.shape[0]
+    node_exists = ~jnp.isnan(nodes[:, 0])
+    admissible = (
+        valid
+        & (src_rows != I_INF)
+        & (dst_rows != I_INF)
+        & (src_rows >= 0)
+        & (src_rows < max_nodes)
+        & (dst_rows >= 0)
+        & (dst_rows < max_nodes)
+    )
+
+    safe_dst = jnp.where(admissible, dst_rows, 0)
+    in_degree = (
+        jnp.zeros((max_nodes,), dtype=jnp.int32)
+        .at[safe_dst]
+        .add(admissible.astype(jnp.int32))
+    )
+
+    def cond_func(carry):
+        _, _, in_degree_, processed_ = carry
+        ready = (in_degree_ == 0) & node_exists & ~processed_
+        return fetch_first(ready) != I_INF
+
+    def body_func(carry):
+        order_, idx_, in_degree_, processed_ = carry
+        ready = (in_degree_ == 0) & node_exists & ~processed_
+        node = fetch_first(ready)
+
+        order_ = order_.at[idx_].set(node)
+        processed_ = processed_.at[node].set(True)
+
+        emitted = admissible & (src_rows == node)
+        safe_target = jnp.where(emitted, dst_rows, 0)
+        decrement = (
+            jnp.zeros_like(in_degree_)
+            .at[safe_target]
+            .add(emitted.astype(jnp.int32))
+        )
+        return order_, idx_ + 1, in_degree_ - decrement, processed_
+
+    order = jnp.full((max_nodes,), I_INF, dtype=jnp.int32)
+    processed = jnp.zeros((max_nodes,), dtype=bool)
+    order, _, _, _ = jax.lax.while_loop(
+        cond_func, body_func, (order, 0, in_degree, processed)
+    )
+    return order
+
+
+def check_cycles_flat(
+    nodes: Array,
+    src_rows: Array,
+    dst_rows: Array,
+    valid: Array,
+    from_idx,
+    to_idx,
+) -> Array:
+    """
+    Check a candidate connection directly against flat endpoint arrays.
+
+    Adding ``from_idx -> to_idx`` creates a cycle exactly when ``from_idx`` is
+    reachable from ``to_idx`` through the existing connections. This traversal
+    uses ``O(N + C)`` storage instead of rebuilding a dense ``(N, N)`` matrix.
+    """
+    max_nodes = nodes.shape[0]
+    admissible = (
+        valid
+        & (src_rows != I_INF)
+        & (dst_rows != I_INF)
+        & (src_rows >= 0)
+        & (src_rows < max_nodes)
+        & (dst_rows >= 0)
+        & (dst_rows < max_nodes)
+    )
+    safe_src = jnp.where(admissible, src_rows, 0)
+    safe_dst = jnp.where(admissible, dst_rows, 0)
+
+    visited = jnp.zeros((max_nodes,), dtype=bool)
+    new_visited = visited.at[to_idx].set(True)
+
+    def cond_func(carry):
+        visited_, new_visited_ = carry
+        stable = jnp.all(visited_ == new_visited_)
+        found_source = new_visited_[from_idx]
+        return ~(stable | found_source)
+
+    def body_func(carry):
+        _, visited_ = carry
+        reached_edges = admissible & visited_[safe_src]
+        new_visited_ = visited_.at[safe_dst].max(reached_edges)
+        return visited_, new_visited_
+
+    _, visited = jax.lax.while_loop(
+        cond_func, body_func, (visited, new_visited)
+    )
+    return visited[from_idx]
+
+
 @jit
 def check_cycles(nodes: Array, conns: Array, from_idx, to_idx) -> Array:
     """

--- a/src/tensorneat/genome/default.py
+++ b/src/tensorneat/genome/default.py
@@ -8,10 +8,16 @@ import sympy as sp
 from .base import BaseGenome
 from .gene import DefaultNode, DefaultConn
 from .operations import DefaultMutation, DefaultCrossover, DefaultDistance
-from .utils import unflatten_conns, extract_gene_attrs, extract_gene_attrs
+from .utils import (
+    build_padded_inbound_adj,
+    extract_gene_attrs,
+    map_conn_endpoints,
+    unflatten_conns,
+)
 
 from tensorneat.common import (
     topological_sort,
+    topological_sort_flat,
     topological_sort_python,
     find_useful_nodes,
     I_INF,
@@ -40,6 +46,7 @@ class DefaultGenome(BaseGenome):
         output_transform=None,
         input_transform=None,
         init_hidden_layers=(),
+        max_in_degree=None,
     ):
 
         super().__init__(
@@ -57,7 +64,41 @@ class DefaultGenome(BaseGenome):
             init_hidden_layers,
         )
 
+        if max_in_degree is not None:
+            if not isinstance(max_in_degree, (int, np.integer)):
+                raise TypeError("max_in_degree must be an integer or None")
+            max_in_degree = int(max_in_degree)
+            if max_in_degree < 1:
+                raise ValueError("max_in_degree must be greater than or equal to 1")
+            if max_in_degree > max_nodes:
+                raise ValueError(
+                    f"max_in_degree={max_in_degree} exceeds max_nodes={max_nodes}"
+                )
+
+            initial_source_widths = [num_inputs] + list(init_hidden_layers)
+            initial_max_in_degree = max(initial_source_widths, default=0)
+            if initial_max_in_degree > max_in_degree:
+                raise ValueError(
+                    "The initial topology requires inbound degree "
+                    f"{initial_max_in_degree}, which exceeds "
+                    f"max_in_degree={max_in_degree}"
+                )
+
+        self.max_in_degree = max_in_degree
+
     def transform(self, state, nodes, conns):
+        if self.max_in_degree is not None:
+            src_rows, dst_rows, valid = map_conn_endpoints(nodes, conns)
+            seqs = topological_sort_flat(nodes, src_rows, dst_rows, valid)
+            adj_conns, overflow = build_padded_inbound_adj(
+                src_rows,
+                dst_rows,
+                valid,
+                self.max_nodes,
+                self.max_in_degree,
+            )
+            return seqs, nodes, conns, adj_conns, src_rows, overflow
+
         u_conns = unflatten_conns(nodes, conns)
         conn_exist = u_conns != I_INF
 
@@ -66,6 +107,8 @@ class DefaultGenome(BaseGenome):
         return seqs, nodes, conns, u_conns
 
     def forward(self, state, transformed, inputs):
+        if self.max_in_degree is not None:
+            return self._forward_padded(state, transformed, inputs)
 
         if self.input_transform is not None:
             inputs = self.input_transform(inputs)
@@ -128,6 +171,82 @@ class DefaultGenome(BaseGenome):
             return vals[self.output_idx]
         else:
             return self.output_transform(vals[self.output_idx])
+
+    def _forward_padded(self, state, transformed, inputs):
+        if self.input_transform is not None:
+            inputs = self.input_transform(inputs)
+
+        cal_seqs, nodes, conns, adj_conns, src_rows, overflow = transformed
+
+        def overflow_output():
+            return jnp.full((self.num_outputs,), jnp.nan)
+
+        def calculate_output():
+            ini_vals = jnp.full((self.max_nodes,), jnp.nan)
+            ini_vals = ini_vals.at[self.input_idx].set(inputs)
+            nodes_attrs = vmap(extract_gene_attrs, in_axes=(None, 0))(
+                self.node_gene, nodes
+            )
+            conns_attrs = vmap(extract_gene_attrs, in_axes=(None, 0))(
+                self.conn_gene, conns
+            )
+
+            def body_func(idx, values):
+                i = cal_seqs[idx]
+
+                def valid_node():
+                    def input_node():
+                        return values
+
+                    def otherwise():
+                        conn_rows = adj_conns[i]
+                        filled = conn_rows != I_INF
+                        safe_conn_rows = jnp.where(filled, conn_rows, 0)
+                        source_rows = src_rows[safe_conn_rows]
+                        safe_source_rows = jnp.where(filled, source_rows, 0)
+
+                        source_values = values[safe_source_rows]
+                        valid_mask = filled & ~jnp.isnan(source_values)
+                        safe_source_values = jnp.where(
+                            valid_mask, source_values, 0.0
+                        )
+                        conn_attrs = conns_attrs[safe_conn_rows]
+                        node_inputs = vmap(
+                            self.conn_gene.forward, in_axes=(None, 0, 0)
+                        )(state, conn_attrs, safe_source_values)
+
+                        value = self.node_gene.forward(
+                            state,
+                            nodes_attrs[i],
+                            node_inputs,
+                            is_output_node=jnp.isin(
+                                nodes[i, 0], self.output_idx
+                            ),
+                            valid_mask=valid_mask,
+                        )
+                        return jax.lax.cond(
+                            jnp.any(valid_mask),
+                            lambda: values.at[i].set(value),
+                            lambda: values,
+                        )
+
+                    return jax.lax.cond(
+                        jnp.isin(i, self.input_idx), input_node, otherwise
+                    )
+
+                return jax.lax.cond(
+                    i != I_INF, valid_node, lambda: values
+                )
+
+            values = jax.lax.fori_loop(
+                0, self.max_nodes, body_func, ini_vals
+            )
+            output = values[self.output_idx]
+            if self.output_transform is not None:
+                output = self.output_transform(output)
+            return output
+
+        return jax.lax.cond(overflow, overflow_output, calculate_output)
 
     def network_dict(self, state, nodes, conns):
         network = super().network_dict(state, nodes, conns)

--- a/src/tensorneat/genome/operations/mutation/default.py
+++ b/src/tensorneat/genome/operations/mutation/default.py
@@ -6,9 +6,11 @@ from tensorneat.common import (
     fetch_random,
     I_INF,
     check_cycles,
+    check_cycles_flat,
 )
 from ...utils import (
     unflatten_conns,
+    map_conn_endpoints,
     add_node,
     add_conn,
     delete_node_by_pos,
@@ -184,12 +186,42 @@ class DefaultMutation(BaseMutation):
                 )
 
             if genome.network_type == "feedforward":
-                u_conns = unflatten_conns(nodes_, conns_)
-                conns_exist = u_conns != I_INF
-                is_cycle = check_cycles(nodes_, conns_exist, from_idx, to_idx)
+                max_in_degree = getattr(genome, "max_in_degree", None)
+                if max_in_degree is None:
+                    destination_is_full = False
+                    u_conns = unflatten_conns(nodes_, conns_)
+                    conns_exist = u_conns != I_INF
+                    is_cycle = check_cycles(
+                        nodes_, conns_exist, from_idx, to_idx
+                    )
+                else:
+                    valid_conn = ~jnp.isnan(conns_[:, 0])
+                    in_degree = jnp.sum(
+                        (
+                            valid_conn
+                            & (conns_[:, 1] == o_key)
+                        ).astype(jnp.int32)
+                    )
+                    destination_is_full = (
+                        in_degree >= max_in_degree
+                    )
+                    src_rows, dst_rows, valid = map_conn_endpoints(
+                        nodes_, conns_
+                    )
+                    is_cycle = check_cycles_flat(
+                        nodes_,
+                        src_rows,
+                        dst_rows,
+                        valid,
+                        from_idx,
+                        to_idx,
+                    )
 
                 return jax.lax.cond(
-                    is_already_exist | is_cycle | (remain_conn_space < 1),
+                    is_already_exist
+                    | is_cycle
+                    | (remain_conn_space < 1)
+                    | destination_is_full,
                     nothing,
                     successful,
                 )

--- a/src/tensorneat/genome/utils.py
+++ b/src/tensorneat/genome/utils.py
@@ -36,6 +36,83 @@ def _batch_key_to_index(query_keys, ref_keys):
     return jnp.where(matched, original_idx, I_INF)
 
 
+def map_conn_endpoints(nodes, conns):
+    """
+    Resolve flat connection endpoint keys to node-row indices.
+
+    Returns ``(src_rows, dst_rows, valid)`` arrays with shape ``(C,)``.
+    ``valid`` is false for padded connections and dangling endpoints.
+    """
+    node_keys = nodes[:, 0]
+    src_rows = _batch_key_to_index(conns[:, 0], node_keys)
+    dst_rows = _batch_key_to_index(conns[:, 1], node_keys)
+    valid = (
+        ~jnp.isnan(conns[:, 0])
+        & ~jnp.isnan(conns[:, 1])
+        & (src_rows != I_INF)
+        & (dst_rows != I_INF)
+    )
+    return src_rows, dst_rows, valid
+
+
+def build_padded_inbound_adj(
+    src_rows, dst_rows, valid, max_nodes, max_in_degree
+):
+    """
+    Pack flat connections into a bounded inbound adjacency.
+
+    The returned ``adj_conns`` has shape ``(max_nodes, max_in_degree)`` and
+    stores row indices into the original connection array. Empty slots contain
+    ``I_INF``. Slots are sorted by source-node row to preserve the reduction
+    order of the legacy dense representation.
+
+    ``overflow`` is true when an admissible destination has more inbound
+    connections than the configured cap.
+    """
+    max_conns = src_rows.shape[0]
+    conn_rows = jnp.arange(max_conns, dtype=jnp.int32)
+    admissible = (
+        valid
+        & (src_rows >= 0)
+        & (src_rows < max_nodes)
+        & (dst_rows >= 0)
+        & (dst_rows < max_nodes)
+    )
+
+    # Pack in the source-row order used by the legacy dense representation.
+    # Invalid connections sort to the tail and are subsequently dropped.
+    safe_src = jnp.where(admissible, src_rows, max_nodes)
+    safe_dst = jnp.where(admissible, dst_rows, max_nodes)
+    order = jnp.lexsort((conn_rows, safe_src, safe_dst))
+    sorted_conn_rows = conn_rows[order]
+    sorted_dst = dst_rows[order]
+    sorted_admissible = admissible[order]
+
+    def assign_slot(counts, item):
+        dst, is_admissible = item
+        safe_dst = jnp.where(is_admissible, dst, 0)
+        slot = counts[safe_dst]
+        counts = counts.at[safe_dst].add(is_admissible.astype(jnp.int32))
+        return counts, slot
+
+    _, slots = jax.lax.scan(
+        assign_slot,
+        jnp.zeros((max_nodes,), dtype=jnp.int32),
+        (sorted_dst, sorted_admissible),
+    )
+
+    within_cap = sorted_admissible & (slots < max_in_degree)
+    overflow = jnp.any(sorted_admissible & ~within_cap)
+    safe_dst = jnp.where(within_cap, sorted_dst, max_nodes)
+
+    adj_conns = (
+        jnp.full((max_nodes, max_in_degree), I_INF, dtype=jnp.int32)
+        .at[safe_dst, slots]
+        .set(sorted_conn_rows, mode="drop")
+    )
+    return adj_conns, overflow
+
+
 def unflatten_conns(nodes, conns):
     """
     transform the (C, CL) connections to (N, N), which contains the idx of the connection in conns

--- a/test/benchmark_padded_adjacency.py
+++ b/test/benchmark_padded_adjacency.py
@@ -1,0 +1,227 @@
+"""
+Benchmark dense and bounded feed-forward graph operations on one revision.
+
+The dense path is selected with ``max_in_degree=None``. The bounded path uses
+the supplied cap. Both variants receive the same initialized population. The
+benchmark covers transformation, forward evaluation, and structural mutation,
+whose cycle check otherwise reconstructs the dense adjacency.
+
+Usage:
+    python test/benchmark_padded_adjacency.py
+    python test/benchmark_padded_adjacency.py \
+        --population 256 --max-nodes 512 --max-conns 2048 --max-in-degree 64
+"""
+
+import argparse
+import os
+import statistics
+import sys
+import time
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src")
+)
+
+import jax
+import jax.numpy as jnp
+
+from tensorneat.genome import DefaultGenome
+
+
+def format_bytes(value):
+    if value < 1024 ** 2:
+        return f"{value / 1024:.1f} KiB"
+    return f"{value / 1024 ** 2:.1f} MiB"
+
+
+def tree_bytes(tree):
+    return sum(
+        leaf.size * leaf.dtype.itemsize
+        for leaf in jax.tree.leaves(tree)
+        if hasattr(leaf, "size") and hasattr(leaf, "dtype")
+    )
+
+
+def block_until_ready(tree):
+    for leaf in jax.tree.leaves(tree):
+        if hasattr(leaf, "block_until_ready"):
+            leaf.block_until_ready()
+
+
+def time_compiled(compiled, args, warmup, repeats):
+    for _ in range(warmup):
+        block_until_ready(compiled(*args))
+
+    samples = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        block_until_ready(compiled(*args))
+        samples.append((time.perf_counter() - start) * 1000)
+    return statistics.median(samples)
+
+
+def make_genome(max_nodes, max_conns, max_in_degree):
+    return DefaultGenome(
+        num_inputs=3,
+        num_outputs=1,
+        max_nodes=max_nodes,
+        max_conns=max_conns,
+        max_in_degree=max_in_degree,
+    )
+
+
+def measure(args, max_in_degree):
+    genome = make_genome(args.max_nodes, args.max_conns, max_in_degree)
+    state = genome.setup()
+    keys = jax.random.split(jax.random.PRNGKey(args.seed), args.population)
+    pop_nodes, pop_conns = jax.vmap(genome.initialize, in_axes=(None, 0))(
+        state, keys
+    )
+    inputs = jnp.array([0.25, -0.5, 0.75])
+    mutation_keys = jax.random.split(
+        jax.random.PRNGKey(args.seed + 1), args.population
+    )
+    new_node_keys = (
+        jnp.arange(args.population, dtype=jnp.float32) + args.max_nodes
+    )
+    new_conn_markers = (
+        jnp.arange(args.population * 3, dtype=jnp.float32)
+        .reshape(args.population, 3)
+        + args.max_conns
+    )
+
+    batch_transform = jax.jit(
+        jax.vmap(genome.transform, in_axes=(None, 0, 0))
+    )
+    batch_mutation = jax.jit(
+        jax.vmap(
+            genome.execute_mutation,
+            in_axes=(None, 0, 0, 0, 0, 0),
+        )
+    )
+
+    def transform_and_forward(nodes, conns):
+        transformed = genome.transform(state, nodes, conns)
+        return genome.forward(state, transformed, inputs)
+
+    batch_full = jax.jit(jax.vmap(transform_and_forward))
+    compiled_transform = batch_transform.lower(
+        state, pop_nodes, pop_conns
+    ).compile()
+    compiled_mutation = batch_mutation.lower(
+        state,
+        mutation_keys,
+        pop_nodes,
+        pop_conns,
+        new_node_keys,
+        new_conn_markers,
+    ).compile()
+    compiled_full = batch_full.lower(pop_nodes, pop_conns).compile()
+
+    transformed = compiled_transform(state, pop_nodes, pop_conns)
+    block_until_ready(transformed)
+    mutated = compiled_mutation(
+        state,
+        mutation_keys,
+        pop_nodes,
+        pop_conns,
+        new_node_keys,
+        new_conn_markers,
+    )
+    block_until_ready(mutated)
+    outputs = compiled_full(pop_nodes, pop_conns)
+    block_until_ready(outputs)
+
+    transform_memory = compiled_transform.memory_analysis()
+    mutation_memory = compiled_mutation.memory_analysis()
+    return {
+        "variant": "dense" if max_in_degree is None else f"K={max_in_degree}",
+        "transform_output_bytes": tree_bytes(transformed),
+        "transform_peak_bytes": transform_memory.peak_memory_in_bytes,
+        "mutation_peak_bytes": mutation_memory.peak_memory_in_bytes,
+        "transform_ms": time_compiled(
+            compiled_transform,
+            (state, pop_nodes, pop_conns),
+            args.warmup,
+            args.repeats,
+        ),
+        "mutation_ms": time_compiled(
+            compiled_mutation,
+            (
+                state,
+                mutation_keys,
+                pop_nodes,
+                pop_conns,
+                new_node_keys,
+                new_conn_markers,
+            ),
+            args.warmup,
+            args.repeats,
+        ),
+        "full_ms": time_compiled(
+            compiled_full,
+            (pop_nodes, pop_conns),
+            args.warmup,
+            args.repeats,
+        ),
+    }
+
+
+def ratio(baseline, candidate, field):
+    return baseline[field] / candidate[field]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--population", type=int, default=256)
+    parser.add_argument("--max-nodes", type=int, default=512)
+    parser.add_argument("--max-conns", type=int, default=2048)
+    parser.add_argument("--max-in-degree", type=int, default=64)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--repeats", type=int, default=7)
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    if args.max_in_degree > args.max_nodes:
+        parser.error("--max-in-degree cannot exceed --max-nodes")
+
+    print(f"Device: {jax.devices()[0]}")
+    print(
+        f"Population={args.population}, N={args.max_nodes}, "
+        f"C={args.max_conns}, K={args.max_in_degree}"
+    )
+    dense = measure(args, None)
+    bounded = measure(args, args.max_in_degree)
+
+    print()
+    print(
+        "| variant | transform output | transform peak | mutation peak "
+        "| transform (ms) | mutation (ms) | transform + forward (ms) |"
+    )
+    print("|---|---:|---:|---:|---:|---:|---:|")
+    for result in (dense, bounded):
+        print(
+            f"| {result['variant']} "
+            f"| {format_bytes(result['transform_output_bytes'])} "
+            f"| {format_bytes(result['transform_peak_bytes'])} "
+            f"| {format_bytes(result['mutation_peak_bytes'])} "
+            f"| {result['transform_ms']:.2f} "
+            f"| {result['mutation_ms']:.2f} "
+            f"| {result['full_ms']:.2f} |"
+        )
+
+    print()
+    print("Dense / bounded ratios (>1 favors bounded):")
+    for field in (
+        "transform_output_bytes",
+        "transform_peak_bytes",
+        "mutation_peak_bytes",
+        "transform_ms",
+        "mutation_ms",
+        "full_ms",
+    ):
+        print(f"  {field}: {ratio(dense, bounded, field):.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_padded_adjacency.py
+++ b/test/test_padded_adjacency.py
@@ -1,0 +1,446 @@
+"""Tests for the bounded inbound adjacency used by DefaultGenome."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tensorneat.common import ACT, AGG, I_INF, check_cycles, check_cycles_flat
+from tensorneat.genome import DefaultGenome, DefaultNode
+from tensorneat.genome.operations import DefaultMutation
+from tensorneat.genome.utils import (
+    build_padded_inbound_adj,
+    map_conn_endpoints,
+    unflatten_conns,
+)
+
+
+def _genome(max_in_degree=None, **kwargs):
+    defaults = {
+        "num_inputs": 2,
+        "num_outputs": 1,
+        "max_nodes": 8,
+        "max_conns": 16,
+        "max_in_degree": max_in_degree,
+    }
+    defaults.update(kwargs)
+    return DefaultGenome(**defaults)
+
+
+def _initialized_pair(seed=0, max_in_degree=2):
+    dense = _genome()
+    padded = _genome(max_in_degree=max_in_degree)
+    dense_state = dense.setup()
+    padded_state = padded.setup()
+    key = jax.random.PRNGKey(seed)
+    nodes, conns = dense.initialize(dense_state, key)
+    return dense, padded, dense_state, padded_state, nodes, conns
+
+
+class TestConfiguration:
+    def test_none_preserves_legacy_transform(self):
+        genome = _genome()
+        state = genome.setup()
+        nodes, conns = genome.initialize(state, jax.random.PRNGKey(0))
+
+        transformed = genome.transform(state, nodes, conns)
+
+        assert genome.max_in_degree is None
+        assert len(transformed) == 4
+        assert transformed[-1].shape == (genome.max_nodes, genome.max_nodes)
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_rejects_non_positive_cap(self, value):
+        with pytest.raises(ValueError, match="greater than or equal to 1"):
+            _genome(max_in_degree=value)
+
+    def test_rejects_cap_larger_than_node_capacity(self):
+        with pytest.raises(ValueError, match="exceeds max_nodes"):
+            _genome(max_in_degree=9)
+
+    def test_rejects_non_integer_cap(self):
+        with pytest.raises(TypeError, match="integer or None"):
+            _genome(max_in_degree=2.5)
+
+    def test_rejects_initial_topology_over_cap(self):
+        with pytest.raises(ValueError, match="initial topology"):
+            _genome(max_in_degree=1)
+
+
+class TestAdjacencyBuilder:
+    def test_packs_slots_in_legacy_source_row_order(self):
+        src_rows = jnp.array([2, 0, 1, I_INF], dtype=jnp.int32)
+        dst_rows = jnp.array([3, 3, 3, I_INF], dtype=jnp.int32)
+        valid = jnp.array([True, True, True, False])
+
+        adj_conns, overflow = build_padded_inbound_adj(
+            src_rows,
+            dst_rows,
+            valid,
+            max_nodes=4,
+            max_in_degree=3,
+        )
+
+        np.testing.assert_array_equal(
+            np.asarray(adj_conns[3]), np.array([1, 2, 0])
+        )
+        assert not bool(overflow)
+
+    def test_reports_overflow_and_keeps_exactly_the_cap(self):
+        src_rows = jnp.array([0, 1, 2], dtype=jnp.int32)
+        dst_rows = jnp.array([3, 3, 3], dtype=jnp.int32)
+        valid = jnp.ones((3,), dtype=bool)
+
+        adj_conns, overflow = build_padded_inbound_adj(
+            src_rows,
+            dst_rows,
+            valid,
+            max_nodes=4,
+            max_in_degree=2,
+        )
+
+        assert bool(overflow)
+        assert int(jnp.sum(adj_conns[3] != I_INF)) == 2
+
+    def test_dangling_endpoints_are_invalid(self):
+        nodes = jnp.array(
+            [
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [jnp.nan, jnp.nan],
+            ]
+        )
+        conns = jnp.array(
+            [
+                [0.0, 1.0, 1.0],
+                [2.0, 1.0, 1.0],
+                [jnp.nan, jnp.nan, jnp.nan],
+            ]
+        )
+
+        src_rows, dst_rows, valid = map_conn_endpoints(nodes, conns)
+
+        np.testing.assert_array_equal(np.asarray(valid), [True, False, False])
+        assert int(src_rows[1]) == I_INF
+        assert int(dst_rows[0]) == 1
+
+
+class TestFlatGraphOperations:
+    @pytest.mark.parametrize(
+        ("from_idx", "to_idx", "expected"),
+        [
+            (3, 0, True),
+            (1, 3, False),
+            (2, 0, True),
+            (1, 1, True),
+        ],
+    )
+    def test_cycle_check_matches_dense_path(
+        self, from_idx, to_idx, expected
+    ):
+        nodes = jnp.array([[0.0], [1.0], [2.0], [3.0], [jnp.nan]])
+        conns = jnp.array(
+            [
+                [0.0, 2.0],
+                [2.0, 3.0],
+                [jnp.nan, jnp.nan],
+                [jnp.nan, jnp.nan],
+            ]
+        )
+        src_rows, dst_rows, valid = map_conn_endpoints(nodes, conns)
+        dense_conns = unflatten_conns(nodes, conns) != I_INF
+
+        dense_result = check_cycles(
+            nodes, dense_conns, from_idx, to_idx
+        )
+        flat_result = jax.jit(check_cycles_flat)(
+            nodes,
+            src_rows,
+            dst_rows,
+            valid,
+            from_idx,
+            to_idx,
+        )
+
+        assert bool(flat_result) is expected
+        assert bool(flat_result) == bool(dense_result)
+
+
+class TestForwardCompatibility:
+    @pytest.mark.parametrize("seed", [0, 1, 7])
+    def test_initialized_network_matches_dense_path(self, seed):
+        dense, padded, dense_state, padded_state, nodes, conns = (
+            _initialized_pair(seed)
+        )
+        inputs = jnp.array([0.25, -0.5])
+
+        dense_output = dense.forward(
+            dense_state,
+            dense.transform(dense_state, nodes, conns),
+            inputs,
+        )
+        padded_output = padded.forward(
+            padded_state,
+            padded.transform(padded_state, nodes, conns),
+            inputs,
+        )
+
+        np.testing.assert_array_equal(dense_output, padded_output)
+
+    @pytest.mark.parametrize(
+        "inputs",
+        [
+            jnp.array([0.25, -0.5]),
+            jnp.array([1.0, 1.0]),
+            jnp.array([-2.0, 0.125]),
+        ],
+    )
+    def test_hidden_dag_matches_dense_path(self, inputs):
+        dense, padded, dense_state, padded_state, nodes, _ = (
+            _initialized_pair(3)
+        )
+        nodes = nodes.at[3].set(nodes[2].at[0].set(3.0))
+        nodes = nodes.at[4].set(nodes[2].at[0].set(4.0))
+        conns = jnp.full((16, 3), jnp.nan)
+        conns = conns.at[:6].set(
+            jnp.array(
+                [
+                    [4.0, 2.0, 0.75],
+                    [1.0, 3.0, -0.5],
+                    [3.0, 4.0, 1.25],
+                    [1.0, 2.0, 0.1],
+                    [0.0, 4.0, -0.25],
+                    [0.0, 3.0, 0.8],
+                ]
+            )
+        )
+
+        dense_transformed = dense.transform(dense_state, nodes, conns)
+        padded_transformed = padded.transform(padded_state, nodes, conns)
+        dense_output = dense.forward(
+            dense_state, dense_transformed, inputs
+        )
+        padded_output = padded.forward(
+            padded_state, padded_transformed, inputs
+        )
+
+        np.testing.assert_array_equal(
+            dense_transformed[0], padded_transformed[0]
+        )
+        np.testing.assert_array_equal(dense_output, padded_output)
+
+    def test_preserves_floating_point_reduction_order(self):
+        dense = _genome(
+            num_inputs=3,
+            max_nodes=4,
+            max_conns=6,
+        )
+        padded = _genome(
+            num_inputs=3,
+            max_nodes=4,
+            max_conns=6,
+            max_in_degree=3,
+        )
+        dense_state = dense.setup()
+        padded_state = padded.setup()
+        nodes, _ = dense.initialize(dense_state, jax.random.PRNGKey(0))
+        nodes = nodes.at[3, 1:].set(jnp.array([0.0, 1.0, 0.0, 0.0]))
+        conns = jnp.full((6, 3), jnp.nan)
+        conns = conns.at[:3].set(
+            jnp.array(
+                [
+                    [1.0, 3.0, -1e20],
+                    [2.0, 3.0, 1.0],
+                    [0.0, 3.0, 1e20],
+                ]
+            )
+        )
+        inputs = jnp.ones((3,))
+
+        dense_output = dense.forward(
+            dense_state,
+            dense.transform(dense_state, nodes, conns),
+            inputs,
+        )
+        padded_output = padded.forward(
+            padded_state,
+            padded.transform(padded_state, nodes, conns),
+            inputs,
+        )
+
+        np.testing.assert_array_equal(dense_output, padded_output)
+        np.testing.assert_array_equal(dense_output, jnp.array([1.0]))
+
+    def test_preserves_maxabs_tie_breaking(self):
+        node_gene = DefaultNode(
+            aggregation_options=AGG.maxabs,
+            activation_options=ACT.identity,
+        )
+        dense = _genome(node_gene=node_gene)
+        padded = _genome(max_in_degree=2, node_gene=node_gene)
+        dense_state = dense.setup()
+        padded_state = padded.setup()
+        nodes, _ = dense.initialize(dense_state, jax.random.PRNGKey(0))
+        nodes = nodes.at[2, 1:].set(jnp.array([0.0, 1.0, 0.0, 0.0]))
+        conns = jnp.full((16, 3), jnp.nan)
+        conns = conns.at[:2].set(
+            jnp.array(
+                [
+                    [1.0, 2.0, 1.0],
+                    [0.0, 2.0, 1.0],
+                ]
+            )
+        )
+        inputs = jnp.array([1.0, -1.0])
+
+        dense_output = dense.forward(
+            dense_state,
+            dense.transform(dense_state, nodes, conns),
+            inputs,
+        )
+        padded_output = padded.forward(
+            padded_state,
+            padded.transform(padded_state, nodes, conns),
+            inputs,
+        )
+
+        np.testing.assert_array_equal(dense_output, padded_output)
+        np.testing.assert_array_equal(dense_output, jnp.array([1.0]))
+
+    def test_overflow_produces_nan_instead_of_truncated_evaluation(self):
+        genome = _genome(
+            max_in_degree=2,
+            num_inputs=2,
+            max_nodes=5,
+            max_conns=8,
+        )
+        state = genome.setup()
+        nodes, _ = genome.initialize(state, jax.random.PRNGKey(0))
+        nodes = nodes.at[3].set(nodes[0].at[0].set(3.0))
+        conns = jnp.full((8, 3), jnp.nan)
+        conns = conns.at[:3].set(
+            jnp.array(
+                [
+                    [0.0, 2.0, 1.0],
+                    [1.0, 2.0, 1.0],
+                    [3.0, 2.0, 1.0],
+                ]
+            )
+        )
+
+        transformed = genome.transform(state, nodes, conns)
+        output = genome.forward(state, transformed, jnp.ones((2,)))
+
+        assert bool(transformed[-1])
+        assert jnp.all(jnp.isnan(output))
+
+    def test_jit_and_vmap(self):
+        genome = _genome(max_in_degree=2)
+        state = genome.setup()
+        keys = jax.random.split(jax.random.PRNGKey(0), 3)
+        nodes, conns = jax.vmap(genome.initialize, in_axes=(None, 0))(
+            state, keys
+        )
+        inputs = jnp.array([0.25, -0.5])
+
+        def evaluate(nodes_, conns_):
+            transformed = genome.transform(state, nodes_, conns_)
+            return genome.forward(state, transformed, inputs)
+
+        outputs = jax.jit(jax.vmap(evaluate))(nodes, conns)
+
+        assert outputs.shape == (3, 1)
+        assert jnp.all(jnp.isfinite(outputs))
+
+    def test_gradients_are_finite(self):
+        genome = _genome(max_in_degree=2)
+        state = genome.setup()
+        nodes, conns = genome.initialize(state, jax.random.PRNGKey(0))
+        inputs = jnp.array([0.25, -0.5])
+
+        def loss(nodes_, conns_):
+            transformed = genome.transform(state, nodes_, conns_)
+            output = genome.forward(state, transformed, inputs)
+            return jnp.sum(output ** 2)
+
+        grad_fn = jax.jit(jax.grad(loss, argnums=(0, 1)))
+        grad_nodes, grad_conns = grad_fn(nodes, conns)
+
+        assert jnp.all(jnp.isfinite(grad_nodes) | jnp.isnan(nodes))
+        assert jnp.all(jnp.isfinite(grad_conns) | jnp.isnan(conns))
+
+
+class TestMutationInvariant:
+    def test_batched_mutation_matches_dense_path_below_cap(self):
+        mutation = DefaultMutation(
+            conn_add=1.0,
+            conn_delete=0.0,
+            node_add=0.0,
+            node_delete=0.0,
+        )
+        dense = _genome(mutation=mutation)
+        padded = _genome(max_in_degree=7, mutation=mutation)
+        dense_state = dense.setup()
+        padded_state = padded.setup()
+        nodes, conns = dense.initialize(
+            dense_state, jax.random.PRNGKey(0)
+        )
+
+        population = 8
+        keys = jax.random.split(jax.random.PRNGKey(1), population)
+        pop_nodes = jnp.repeat(nodes[None, ...], population, axis=0)
+        pop_conns = jnp.repeat(conns[None, ...], population, axis=0)
+        new_node_keys = jnp.arange(population, dtype=jnp.float32) + 100
+        new_conn_markers = (
+            jnp.arange(population * 3, dtype=jnp.float32)
+            .reshape(population, 3)
+            + 1000
+        )
+
+        def mutate_batch(genome, state):
+            return jax.jit(
+                jax.vmap(
+                    genome.execute_mutation,
+                    in_axes=(None, 0, 0, 0, 0, 0),
+                )
+            )(
+                state,
+                keys,
+                pop_nodes,
+                pop_conns,
+                new_node_keys,
+                new_conn_markers,
+            )
+
+        dense_nodes, dense_conns = mutate_batch(dense, dense_state)
+        padded_nodes, padded_conns = mutate_batch(padded, padded_state)
+
+        np.testing.assert_array_equal(dense_nodes, padded_nodes)
+        np.testing.assert_array_equal(dense_conns, padded_conns)
+
+    def test_add_connection_respects_full_destination(self):
+        genome = _genome(
+            max_in_degree=2,
+            mutation=DefaultMutation(
+                conn_add=1.0,
+                conn_delete=0.0,
+                node_add=0.0,
+                node_delete=0.0,
+            ),
+        )
+        state = genome.setup()
+        nodes, conns = genome.initialize(state, jax.random.PRNGKey(0))
+        initial_count = int(jnp.sum(~jnp.isnan(conns[:, 0])))
+
+        for step in range(5):
+            nodes, conns = genome.execute_mutation(
+                state,
+                jax.random.PRNGKey(step + 1),
+                nodes,
+                conns,
+                jnp.array(100 + step, dtype=jnp.float32),
+                jnp.arange(3, dtype=jnp.float32) + 1000 + 3 * step,
+            )
+
+        final_count = int(jnp.sum(~jnp.isnan(conns[:, 0])))
+        assert final_count == initial_count


### PR DESCRIPTION
# Proposed title

Reduce feed-forward adjacency memory for sparse, high-capacity genomes

## Why

TensorNEAT's central idea is to turn irregular NEAT graphs into fixed-shape
tensors so JAX can compile and vectorize whole populations. That representation
is the source of its accelerator performance, but it also creates the
space-time trade-off described in the TensorNEAT papers: feed-forward
transformation expands every genome to an `N x N` connection representation,
even when the evolved graph is sparse.

This becomes important when `max_nodes` is deliberately set high enough to
leave room for topology growth. The April 2026 memory work in #41 bounds the
population axis with `pop_batch_size`, reducing the quadratic tier from
`O(P * N^2)` to `O(B * N^2)`. The per-genome `N^2` term remains, however, and
continues to dominate when `N` is large.

For workloads that can place a meaningful upper bound `K` on node fan-in, this
PR extends the same fixed-shape design rather than replacing it:

```text
dense transformed adjacency:   O(B * N^2)
bounded inbound adjacency:     O(B * N * K)
```

The representation is still static, JIT-compatible, and population-parallel.
It is opt-in because the trade-off is not universal: at the repository's
default-scale networks, packing the bounded representation can cost more time
than the smaller adjacency saves.

Related context: #38 and #41.

## What

- Add `max_in_degree` to `DefaultGenome`.
  - `None` keeps the current dense transform and forward paths unchanged.
  - An integer enables a fixed `(max_nodes, max_in_degree)` inbound table.
- Reuse the existing `argsort + searchsorted` endpoint mapping introduced for
  #38, then pack connection row indices by destination.
- Preserve the dense path's source-row reduction order so floating-point sums
  and order-sensitive aggregations retain existing behavior.
- Use a flat-edge topological sort so the bounded path does not reconstruct an
  `N x N` cycle matrix during transformation.
- Check candidate mutations for cycles directly from flat endpoints in
  `O(N + C)` storage instead of rebuilding an `N x N` matrix.
- Validate the initial topology and prevent `DefaultMutation` from adding a
  connection to a destination that is already at the cap.
- Return NaN outputs if an externally supplied or custom-mutated genome exceeds
  the cap, rather than silently truncating connections.
- Keep `RecurrentGenome` out of scope; its stateful representation has different
  semantics.

`max_in_degree` is appended to the constructor signature, so existing
positional calls remain compatible.

## Correctness and invariants

The regression tests cover:

- exact equality with the dense path for initialized and non-trivial DAGs;
- the dense path's floating-point reduction order;
- tie-breaking for the order-sensitive `maxabs` aggregation;
- JIT, `vmap`, and autodiff compatibility;
- invalid and dangling endpoint handling;
- cap validation, overflow signaling, and mutation enforcement;
- bit-identical batched JIT mutation while the cap is non-binding; and
- unchanged dense transform shape when `max_in_degree=None`.

All 26 feature tests pass on Python 3.10 with the repository's declared minimum
JAX version, 0.4.28. The 16 existing gradient tests pass in the same environment
with the default dense path. Focused real-JIT `vmap` and gradient tests also
pass; the compatibility checks are not limited to eager execution.

## Preliminary benchmark

Apple M2 CPU, JAX 0.11.0, current branch based on `ee20490`. Each row compares
the same initialized population; timings are medians after three warmups and
seven measured runs. "Peak" is XLA's compiled transform peak-memory estimate,
not process RSS.

| Population, N, C, K | Transform output | Compiled transform peak | Mutation | Transform + forward |
|---|---:|---:|---:|---:|
| 1000, 50, 100, 16 | 11.8 -> 5.7 MiB (2.07x) | 13.9 -> 7.8 MiB (1.78x) | 19.36 -> 18.09 ms (1.07x) | 8.19 -> 9.91 ms (0.83x) |
| 512, 200, 1000, 32 | 86.3 -> 22.7 MiB (3.81x) | 94.1 -> 30.5 MiB (3.09x) | 67.06 -> 69.48 ms (0.97x) | 73.36 -> 72.78 ms (1.01x) |
| 256, 512, 2048, 64 | 265.0 -> 43.0 MiB (6.16x) | 273.5 -> 51.5 MiB (5.31x) | 130.78 -> 66.03 ms (1.98x) | 337.97 -> 117.48 ms (2.88x) |

The transform alone is slower in all three CPU configurations because the
bounded path sorts and packs flat connections. The end-to-end crossover occurs
between the default and medium configurations here; this option is intended for
large, sparse graph capacities where memory pressure and repeated forward
calculation outweigh packing cost.

The repository includes the benchmark harness so reviewers can reproduce these
numbers and run the same comparison on CUDA. I would run the current patch on a
T4 before treating any earlier prototype GPU numbers as evidence for this PR.

## Review questions

1. Is `max_in_degree` on `DefaultGenome` the right public boundary for this
   workload-specific constraint?
2. Is NaN-on-overflow consistent with the failure semantics you want for
   structurally invalid genomes?
3. Would you prefer the bounded path to land behind an experimental name until
   it has been exercised on more custom genes and aggregations?

## Test commands

```bash
PYTHONPATH=src pytest -q test/test_padded_adjacency.py
PYTHONPATH=src pytest -q test/test_grad.py
PYTHONPATH=src python test/benchmark_padded_adjacency.py \
  --population 256 \
  --max-nodes 512 \
  --max-conns 2048 \
  --max-in-degree 64
```

Note: an unfiltered repository-wide `pytest` currently fails during collection
on the unchanged legacy imports in `test/test_genome.py` and
`test/test_nan_fitness.py`.
